### PR TITLE
archipelago: Introduce BLKTAP_ENABLED conf variable

### DIFF
--- a/conf/archipelago.conf
+++ b/conf/archipelago.conf
@@ -3,6 +3,8 @@
 USER=root
 # Switch peer processes to run as this group
 GROUP=root
+# Enable blktap module. Possible values: True/False
+BLKTAP_ENABLED=True
 
 # xseg
 [XSEG]

--- a/conf/archipelago.conf.rados_example
+++ b/conf/archipelago.conf.rados_example
@@ -3,6 +3,8 @@
 USER=root
 # Switch peer processes to run as this group
 GROUP=root
+# Enable blktap module. Possible values: True/False
+BLKTAP_ENABLED=True
 
 # xseg
 #SPEC="segdev:xsegbd:1024:5120:12"

--- a/python/archipelago/cli.py
+++ b/python/archipelago/cli.py
@@ -254,6 +254,9 @@ def main():
         kwargs = vars(args)
         # if parser_func == archipelago_parser:
             # peers = construct_peers()
+        if parser_func == vlmc_parser and config['BLKTAP_ENABLED'] is False:
+            print red("Blktap module is disabled.")
+            return -1
         args.func(cli=True, **kwargs)
         return 0
     except Error as e:

--- a/python/archipelago/common.py
+++ b/python/archipelago/common.py
@@ -729,6 +729,7 @@ def loadrc(rc):
     config['VTOOL_END'] = cfg.getint('XSEG','VTOOL_END')
     config['USER'] = cfg.get('ARCHIPELAGO','USER')
     config['GROUP'] = cfg.get('ARCHIPELAGO','GROUP')
+    config['BLKTAP_ENABLED'] = cfg.getboolean('ARCHIPELAGO','BLKTAP_ENABLED')
     roles = cfg.get('PEERS', 'ROLES')
     roles = str(roles)
     roles = roles.split(' ')


### PR DESCRIPTION
Set True or False BLKTAP_ENABLED configuration variable to control
whether 'archipelago' and 'vlmc' commands should check for the
existence of the blktap module.
If blktap module is disabled 'vlmc' command won't proceed with
it's operations and it won't unload blktap module if already
loaded. This gives the ability to the administrator to continue
working with blktap independently without interfering with Archipelago.
The intention for this addition is to support peers that use Archipelago
without the need of blktap.
