### PR TITLE
ext_scripts: Always use assume_v0 on create

### DIFF
--- a/ganeti/ext_scripts/vlmc_wrapper.py
+++ b/ganeti/ext_scripts/vlmc_wrapper.py
@@ -53,6 +53,7 @@ def ReadEnv():
     return {"name": name,
             "size": os.getenv("VOL_SIZE"),
             "origin": os.getenv("EXTP_ORIGIN"),
+            "origin_size": os.getenv("EXTP_ORIGIN_SIZE", "-1"),
             "snapshot_name": os.getenv("VOL_SNAPSHOT_NAME"),
             }
 
@@ -62,9 +63,11 @@ def create(env):
     name = env.get("name")
     size = env.get("size")
     origin = env.get("origin")
+    origin_size = env.get("origin_size")
     sys.stderr.write("Creating volume '%s' of size '%s' from '%s'\n"
                      % (name, size, origin))
-    vlmc.create(name=name, size=int(size), snap=origin)
+    vlmc.create(name=name, size=int(size), snap=origin, assume_v0=True,
+                v0_size=int(origin_size))
     return 0
 
 


### PR DESCRIPTION
Always use assume_v0 when creating a new volume. Also extend the scripts to take
an extra "origin_size" argument, to be used as the provided v0_size.
