### PR TITLE
poold: Log epoll wait() failure

### DIFF
--- a/src/poold/epoll.cc
+++ b/src/poold/epoll.cc
@@ -19,9 +19,9 @@
 #include <stdexcept>
 #include <cstdio>
 #include <cstdlib>
+#include <cerrno>
 
 #include <unistd.h>
-#include <errno.h>
 #include "epoll.hh"
 
 namespace archipelago {
@@ -47,7 +47,6 @@ bool Epoll::add_fd(int fd, uint32_t events)
     ev.data.fd = fd;
     ev.events = events;
     if (epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
-        perror("epoll_ctl: fd");
         return false;
     }
     return true;
@@ -72,7 +71,6 @@ bool Epoll::rm_fd(int fd, uint32_t events)
     ev.data.fd = fd;
     ev.events = events;
     if (epoll_ctl(epollfd, EPOLL_CTL_DEL, fd, &ev) == -1) {
-        perror("epoll_ctl: fd");
         return false;
     }
     return true;
@@ -97,7 +95,6 @@ bool Epoll::set_fd_pollin(int fd, uint32_t events)
     ev.data.fd = fd;
     ev.events = events | EPOLLIN;
     if (epoll_ctl(epollfd, EPOLL_CTL_MOD, fd, &ev) == -1) {
-        perror("epoll_ctl: fd");
         return false;
     }
     return true;
@@ -109,7 +106,6 @@ bool Epoll::reset_fd_pollin(int fd, uint32_t events)
     ev.data.fd = fd;
     ev.events = events & ~((short) EPOLLIN);
     if (epoll_ctl(epollfd, EPOLL_CTL_MOD, fd, &ev) == -1) {
-        perror("epoll_ctl: fd");
         return false;
     }
     return true;
@@ -179,12 +175,7 @@ bool Epoll::reset_socket_pollout(Socket& socket)
 int Epoll::wait(struct epoll_event *events, int maxevents,
         int timeout)
 {
-    int nfds = epoll_wait(epollfd, events, maxevents, timeout);
-    if (nfds == -1 && errno != EINTR) {
-        perror("epoll_wait");
-        exit(EXIT_FAILURE);
-    }
-    return nfds;
+    return epoll_wait(epollfd, events, maxevents, timeout);
 }
 
 }

--- a/src/poold/poold.cc
+++ b/src/poold/poold.cc
@@ -24,6 +24,7 @@
 #include <utility>
 #include <algorithm>
 #include <cstdlib>
+#include <cerrno>
 #include <functional>
 
 #include <arpa/inet.h>
@@ -236,6 +237,10 @@ void Poold::serve_forever()
     poolmsg_t *msg;
     while (Poold::bRunning) {
         int nfds = epoll.wait(events, 20, -1);
+        if (nfds == -1 && errno != EINTR) {
+            logfatal("epoll.wait fatal error. Aborting...");
+            exit(EXIT_FAILURE);
+        }
         if (!Poold::bRunning) {
             break; //Cleanup
         }


### PR DESCRIPTION
Log the reason epoll wait() fails and then abort.