### PR TITLE
poold: Add formatted output logging functions in Logger class

### DIFF
--- a/src/poold/logger.cc
+++ b/src/poold/logger.cc
@@ -16,8 +16,10 @@
  *
  */
 
-#include "logger.hh"
+#include <cstdio>
+#include <cstdarg>
 #include <log4cplus/configurator.h>
+#include "logger.hh"
 
 namespace archipelago {
 
@@ -73,6 +75,19 @@ void Logger::logGeneric(int loglevel, const std::string& msg)
     }
 }
 
+std::string Logger::toString(const char *fmt, va_list ap)
+{
+    va_list args;
+    va_copy(args, ap);
+    size_t size = ::vsnprintf(NULL, 0, fmt, args);
+    std::string buffer;
+    buffer.reserve(size + 1);
+    buffer.resize(size);
+    va_copy(args, ap);
+    ::vsnprintf(&buffer[0], size + 1, fmt, args);
+    return buffer;
+}
+
 void Logger::logerror(const std::string& msg)
 {
     logGeneric(ERROR_LOG_LEVEL, msg);
@@ -101,6 +116,84 @@ void Logger::logwarn(const std::string& msg)
 void Logger::logtrace(const std::string& msg)
 {
     logGeneric(TRACE_LOG_LEVEL, msg);
+}
+
+void Logger::vflogerror(const char *msg, va_list ap)
+{
+    logerror(toString(msg, ap));
+}
+
+void Logger::vflogfatal(const char *msg, va_list ap)
+{
+    logfatal(toString(msg, ap));
+}
+
+void Logger::vfloginfo(const char *msg, va_list ap)
+{
+    loginfo(toString(msg, ap));
+}
+
+void Logger::vflogdebug(const char *msg, va_list ap)
+{
+    logdebug(toString(msg, ap));
+}
+
+void Logger::vflogwarn(const char *msg, va_list ap)
+{
+    logwarn(toString(msg, ap));
+}
+
+void Logger::vflogtrace(const char *msg, va_list ap)
+{
+    logtrace(toString(msg, ap));
+}
+
+void Logger::flogerror(const char *msg, ...)
+{
+    va_list args;
+    va_start(args, msg);
+    vflogerror(msg, args);
+    va_end(args);
+}
+
+void Logger::flogfatal(const char *msg, ...)
+{
+    va_list args;
+    va_start(args, msg);
+    vflogfatal(msg, args);
+    va_end(args);
+}
+
+void Logger::floginfo(const char *msg, ...)
+{
+    va_list args;
+    va_start(args, msg);
+    vfloginfo(msg, args);
+    va_end(args);
+}
+
+void Logger::flogdebug(const char *msg, ...)
+{
+    va_list args;
+    va_start(args, msg);
+    vflogdebug(msg, args);
+    va_end(args);
+}
+
+void Logger::flogwarn(const char *msg, ...)
+{
+    va_list args;
+    va_start(args, msg);
+    vflogwarn(msg, args);
+    va_end(args);
+}
+
+void Logger::flogtrace(const char *msg, ...)
+{
+    va_list args;
+    va_start(args, msg);
+    vflogtrace(msg, args);
+    va_end(args);
 }
 
 }

--- a/src/poold/logger.hh
+++ b/src/poold/logger.hh
@@ -19,6 +19,7 @@
 #ifndef LOGGER_HH
 #define LOGGER_HH
 
+#include <cstdarg>
 #include <log4cplus/logger.h>
 
 namespace archipelago {
@@ -33,9 +34,25 @@ public:
     void logdebug(const std::string& msg);
     void logwarn(const std::string& msg);
     void logtrace(const std::string& msg);
+
+    void flogerror(const char *msg, ...);
+    void flogfatal(const char *msg, ...);
+    void floginfo(const char *msg, ...);
+    void flogdebug(const char *msg, ...);
+    void flogwarn(const char *msg, ...);
+    void flogtrace(const char *msg, ...);
+
+    void vflogerror(const char *msg, va_list ap);
+    void vflogfatal(const char *msg, va_list ap);
+    void vfloginfo(const char *msg, va_list ap);
+    void vflogdebug(const char *msg, va_list ap);
+    void vflogwarn(const char *msg, va_list ap);
+    void vflogtrace(const char *msg, va_list ap);
+
 private:
     log4cplus::Logger logger;
     void logGeneric(int loglevel, const std::string& msg);
+    std::string toString(const char *fmt, va_list ap);
 };
 
 }


### PR DESCRIPTION
The extended class provides the following family of
functions that produce formatted output:

* flogfatal(const char *msg, ...)
* flogerror(const char *msg, ...)
* flogwarn(const char *msg, ...)
* floginfo(const char *msg, ...)
* flogdebug(const char *msg, ...)
* flogtrace(const char *msg, ...)

* vflogfatal(const char *msg, va_list ap)
* vflogerror(const char *msg, va_list ap)
* vflogwarn(const char *msg, va_list ap)
* vfloginfo(const char *msg, va_list ap)
* vflogdebug(const char *msg, va_list ap)
* vflogtrace(const char *msg, va_list ap)

Signed-off-by: Chrysostomos Nanakos <cnanakos@grnet.gr>