### PR TITLE
logger: Add formatted output logging functions

### DIFF
--- a/src/logger.h
+++ b/src/logger.h
@@ -1,0 +1,71 @@
+/*
+Copyright (C) 2015 GRNET S.A.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef __CLOGGER_H
+#define __CLOGGER_H
+
+#include <stdarg.h>
+
+typedef void Logger_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Initialize a new logger
+ * param conffile: log4cplus configuration file
+ * param instance: logger instance name
+ * return: logger instance on success, or NULL on fail
+ */
+Logger_t *logger_new(const char *conffile, const char *instance);
+
+/*
+ * Destroy logger instance
+ * param logger: logger instance
+ */
+void logger_destroy(Logger_t *logger);
+
+/*
+ * Print formatted output message
+ * param logger: logger instance
+ * param msg: format string
+ */
+void flogger_error(const Logger_t *logger, const char *msg, ...);
+void flogger_fatal(const Logger_t *logger, const char *msg, ...);
+void flogger_info(const Logger_t *logger, const char *msg, ...);
+void flogger_debug(const Logger_t *logger, const char *msg, ...);
+void flogger_warn(const Logger_t *logger, const char *msg, ...);
+void flogger_trace(const Logger_t *logger, const char *msg, ...);
+
+/*
+ * Print formatted output message
+ * param logger: logger instance
+ * param msg: format string
+ * param ap: variable argument list
+ */
+void vflogger_error(const Logger_t *logger, const char *msg, va_list ap);
+void vflogger_fatal(const Logger_t *logger, const char *msg, va_list ap);
+void vflogger_info(const Logger_t *logger, const char *msg, va_list ap);
+void vflogger_debug(const Logger_t *logger, const char *msg, va_list ap);
+void vflogger_warn(const Logger_t *logger, const char *msg, va_list ap);
+void vflogger_trace(const Logger_t *logger, const char *msg, va_list ap);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/util/logger_wrap.cc
+++ b/src/util/logger_wrap.cc
@@ -1,0 +1,174 @@
+/*
+Copyright (C) 2015 GRNET S.A.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <string>
+#include <cstdarg>
+#include <stdexcept>
+#include <exception>
+#include "../logger.h"
+#include "../poold/logger.hh"
+
+extern "C" {
+
+Logger_t *logger_new(const char *conffile, const char *instance)
+{
+    archipelago::Logger *lp;
+    std::string cfile;
+    if (!instance) {
+        return NULL;
+    }
+
+    if (conffile) {
+        cfile.append(conffile);
+    }
+    std::string cinst(instance);
+    try {
+        lp = new archipelago::Logger(cfile, cinst);
+        return (Logger_t *) lp;
+    } catch (std::bad_alloc&) {
+        std::clog << "out of memory" << std::endl;
+    } catch (std::exception& x) {
+        std::clog << "Exception: " << x.what() << std::endl;
+    } catch (...) {
+        std::clog << "Unexpected unknown error" << std::endl;
+    }
+    return NULL;
+}
+
+void logger_destroy(Logger_t *logger)
+{
+    if (logger) {
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        delete lp;
+    }
+}
+
+void flogger_error(const Logger_t *logger, const char *msg, ...)
+{
+    if (logger) {
+        va_list ap;
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        va_start(ap, msg);
+        lp->vflogerror(msg, ap);
+        va_end(ap);
+    }
+}
+
+void flogger_fatal(const Logger_t *logger, const char *msg, ...)
+{
+    if (logger) {
+        va_list ap;
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        va_start(ap, msg);
+        lp->vflogfatal(msg, ap);
+        va_end(ap);
+    }
+}
+
+void flogger_info(const Logger_t *logger, const char *msg, ...)
+{
+    if (logger) {
+        va_list ap;
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        va_start(ap, msg);
+        lp->vfloginfo(msg, ap);
+        va_end(ap);
+    }
+}
+
+void flogger_debug(const Logger_t *logger, const char *msg, ...)
+{
+    if (logger) {
+        va_list ap;
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        va_start(ap, msg);
+        lp->vflogdebug(msg, ap);
+        va_end(ap);
+    }
+}
+
+void flogger_warn(const Logger_t *logger, const char *msg, ...)
+{
+    if (logger) {
+        va_list ap;
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        va_start(ap, msg);
+        lp->vflogwarn(msg, ap);
+        va_end(ap);
+    }
+}
+
+void flogger_trace(const Logger_t *logger, const char *msg, ...)
+{
+    if (logger) {
+        va_list ap;
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        va_start(ap, msg);
+        lp->vflogfatal(msg, ap);
+        va_end(ap);
+    }
+}
+
+void vflogger_error(const Logger_t *logger, const char *msg, va_list ap)
+{
+    if (logger) {
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        lp->vflogerror(msg, ap);
+    }
+}
+
+void vflogger_fatal(const Logger_t *logger, const char *msg, va_list ap)
+{
+    if (logger) {
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        lp->vflogfatal(msg, ap);
+    }
+}
+
+void vflogger_info(const Logger_t *logger, const char *msg, va_list ap)
+{
+    if (logger) {
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        lp->vfloginfo(msg, ap);
+    }
+}
+
+void vflogger_debug(const Logger_t *logger, const char *msg, va_list ap)
+{
+    if (logger) {
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        lp->vflogdebug(msg, ap);
+    }
+}
+
+void vflogger_warn(const Logger_t *logger, const char *msg, va_list ap)
+{
+    if (logger) {
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        lp->vflogwarn(msg, ap);
+    }
+}
+
+void vflogger_trace(const Logger_t *logger, const char *msg, va_list ap)
+{
+    if (logger) {
+        archipelago::Logger *lp = (archipelago::Logger *)logger;
+        lp->vflogfatal(msg, ap);
+    }
+}
+
+}


### PR DESCRIPTION
This commit adds the following thread-safe family of functions
that produce formatted output and depend on the generic
Logger class.

* logger_new(const char *conffile, const char *instance)
* logger_destroy(Logger_t *logger)

* void flogger_error(const Logger_t *logger, const char *msg, ...)
* void flogger_fatal(const Logger_t *logger, const char *msg, ...)
* void flogger_info(const Logger_t *logger, const char *msg, ...)
* void flogger_debug(const Logger_t *logger, const char *msg, ...)
* void flogger_warn(const Logger_t *logger, const char *msg, ...)
* void flogger_trace(const Logger_t *logger, const char *msg, ...)

* void vflogger_error(const Logger_t *logger, const char *msg, va_list ap)
* void vflogger_fatal(const Logger_t *logger, const char *msg, va_list ap)
* void vflogger_info(const Logger_t *logger, const char *msg, va_list ap)
* void vflogger_debug(const Logger_t *logger, const char *msg, va_list ap)
* void vflogger_warn(const Logger_t *logger, const char *msg, va_list ap)
* void vflogger_trace(const Logger_t *logger, const char *msg, va_list ap)

Signed-off-by: Chrysostomos Nanakos <cnanakos@grnet.gr>