### PR TITLE
Refactoring conditional directives that break parts of statements.

### DIFF
--- a/src/peer.c
+++ b/src/peer.c
@@ -627,6 +627,7 @@ static int generic_peerd_loop(void *arg)
     threshold /= (1 + portno_end - portno_start);
     threshold += 1;
     uint64_t loops;
+    uint64_t test;
 
     XSEGLOG2(&lc, I, "%s has tid %u.\n", id, pid);
     //for (;!(isTerminate() && xq_count(&peer->free_reqs) == peer->nr_ops);) {
@@ -636,10 +637,11 @@ static int generic_peerd_loop(void *arg)
             if (loops == 1)
                 xseg_prepare_wait(xseg, peer->portno_start);
 #ifdef MT
-            if (check_ports(peer, t))
+            test = check_ports(peer, t);
 #else
-            if (check_ports(peer))
+            test = check_ports(peer);
 #endif
+            if (test)
                 loops = threshold;
         }
 #ifdef ST_THREADS


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

```
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/
```

It might improve code understanding, maintainability and error-proneness.
