### PR TITLE
deb: Fix lintian errors and warnings

### DIFF
--- a/debian/archipelago.conffiles
+++ b/debian/archipelago.conffiles
@@ -1,1 +1,0 @@
-/etc/archipelago/archipelago.conf

--- a/debian/archipelago.init.d
+++ b/debian/archipelago.init.d
@@ -1,7 +1,7 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          archipelago
-# Required-Start:    $network $local_fs $remote_fs $all
+# Required-Start:    $network $local_fs $remote_fs
 # Required-Stop:     $remote_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6

--- a/debian/archipelago.postinst
+++ b/debian/archipelago.postinst
@@ -23,7 +23,8 @@ case "$1" in
 	    # Make sure the administrative user exists
 	    if ! getent passwd archipelago > /dev/null; then
 		    adduser --system --quiet --no-create-home \
-			    --group --gecos "Archipelago user" archipelago
+			    --home /var/run/archipelago --group \
+			    --gecos "Archipelago user" archipelago
 	    fi
 	    # if the user was created manually, make sure the group is there as
 	    # well

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Filippos Giannakos <philipgian@grnet.gr>
 Build-Depends: debhelper (>= 7.0.50~), python, libst-dev, libxseg-dev(>>0.4),
  librados-dev(=0.61.2+grnet2-1) | librados-dev(>=0.65),
  libssl-dev, cmake(>=2.8)
-Standards-Version: 3.9.1
+Standards-Version: 3.9.6
 X-Python-Version: >=2.6
 
 Package: python-archipelago
@@ -21,7 +21,7 @@ Description: Python archipelago module
 Package: archipelago
 Architecture: amd64
 Depends: ${misc:Depends},  ${shlibs:Depends}, ${python:Depends},
- libxseg0(>>0.4), python-archipelago(=${binary:Version})
+ libxseg0(>>0.4), python-archipelago(=${binary:Version}), adduser
 Provides: archipelago-protocol1
 Replaces: archipelago-modules-dkms, archipelago-modules-0.3.5,
  archipelago-modules-0.3.4, archipelago-modules-0.3.3,


### PR DESCRIPTION
* Remove unneeded conffile. All files under /etc are treated as
  configuration files automatically
* Remove "$all" from "required-start" field of init.d.
* Add useradd in the package dependencies
* Add /var/run/archipelago as homepage for the archipelago user
* Change standards version to 3.9.6